### PR TITLE
String parameter fix

### DIFF
--- a/src/generic.rs
+++ b/src/generic.rs
@@ -63,7 +63,7 @@ pub trait GenericThumbnail{
     fn invert(&mut self) -> &mut dyn GenericThumbnail;
 
     fn exif(&mut self, metadata: Exif) -> &mut dyn GenericThumbnail;
-    fn text(&mut self, text: str, pos: BoxPosition) -> &mut dyn GenericThumbnail;
+    fn text(&mut self, text: String, pos: BoxPosition) -> &mut dyn GenericThumbnail;
 
     fn combine(&mut self, image: &StaticThumbnail, pos: BoxPosition) -> &mut dyn GenericThumbnail;
 }


### PR DESCRIPTION
Paremeter needs to be String not str, because its size cannot be known at compile time